### PR TITLE
Fixed moviweb apiVersion and added selector

### DIFF
--- a/istio/traffic/movieweb.yaml
+++ b/istio/traffic/movieweb.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
     name: movieweb
@@ -7,6 +7,10 @@ metadata:
         version: v1
 spec:
     replicas: 3
+    selector:
+      matchLabels:
+        app: movieweb
+        version: v1
     template:
         metadata:
             labels:


### PR DESCRIPTION
error: unable to recognize "movieweb.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"

Small mistake, other deployments have correct apiVersion.